### PR TITLE
workJob fails to work for chained jobs because of undefined variable

### DIFF
--- a/src/PHPQueue/Runner.php
+++ b/src/PHPQueue/Runner.php
@@ -115,7 +115,7 @@ abstract class Runner
                 if (is_string($newJob->worker)) {
                     $result_data = $this->processWorker($newJob->worker, $newJob);
                 } elseif (is_array($newJob->worker)) {
-                    $this->logger->addInfo(sprintf("Running chained new job (%s) with workers", $new_job->job_id), $newJob->worker);
+                    $this->logger->addInfo(sprintf("Running chained new job (%s) with workers", $newJob->job_id), $newJob->worker);
                     foreach ($newJob->worker as $worker_name) {
                         $result_data = $this->processWorker($worker_name, $newJob);
                         $newJob->data = $result_data;


### PR DESCRIPTION
At this line, there is an undefined object new_job.  Changed it to newJob. https://github.com/CoderKungfu/php-queue/blob/master/src/PHPQueue/Runner.php#L118
