### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PHP-Queue#
+# PHP-Queue #
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/CoderKungfu/php-queue?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A unified front-end for different queuing backends. Includes a REST server, CLI interface and daemon runners.

--- a/demo/runners/README.md
+++ b/demo/runners/README.md
@@ -185,7 +185,7 @@ To make it into a service that starts on boot-up.
 1. Add this to the top of your script:
 
 	```
-#!/usr/bin/php
+# !/usr/bin/php
 <?php
 #
 # BeanstalkSampleDaemon    Starts the PHP-Queue runner for BeanstalkSample


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
