### PR TITLE
Testing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ dist: trusty
 matrix:
   include:
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,3 @@ before_script:
 
 script: phpunit --coverage-text -c phpunit.travis.xml
 
-after_script:
-  - "wget --quiet http://mauris.sg/bin/pdc.phar && php pdc.phar src"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ mysql:
   username: root
   encoding: utf8
 
+before_install: echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
 before_script:
   - mysql -e 'create database phpqueuetest;'
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,17 @@
 #
 
 language: php
+
 dist: trusty
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
  
 matrix:
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: hhvm
   allow_failures:
     - php: 7.0
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     - php: 7.0
     - php: hhvm
   allow_failures:
+    - php: 5.3
+      dist: precise
     - php: 7.0
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 #
 
 language: php
+dist: trusty
 php:
   - 5.3
   - 5.4

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "http://github.com/CoderKungfu/php-queue",
     "type": "library",
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "Michael Cheng",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "mrpoundsign/pheanstalk-5.3": "dev-master",
-        "aws/aws-sdk-php": "dev-master",
+        "aws/aws-sdk-php": ">=2.8",
         "amazonwebservices/aws-sdk-for-php": "dev-master",
         "predis/predis": "1.*",
         "iron-io/iron_mq": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "predis/predis": "1.*",
         "iron-io/iron_mq": "dev-master",
         "ext-memcache": "*",
-        "microsoft/windowsazure": "dev-master"
+        "microsoft/windowsazure": ">=1.0"
     },
     "suggest": {
         "predis/predis": "For Redis backend support",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "predis/predis": "1.*",
         "iron-io/iron_mq": "dev-master",
         "ext-memcache": "*",
-        "microsoft/windowsazure": ">=1.0"
+        "microsoft/windowsazure": ">=0.4.0"
     },
     "suggest": {
         "predis/predis": "For Redis backend support",


### PR DESCRIPTION
It looks like we can't install Microsoft Azure libs on 5.3, and I'm not sure how to get memcache.so working on 7.0 and hhvm, but this at least gets Travis tests passing on 5.4-5.6