### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "predis/predis": "1.*",
         "iron-io/iron_mq": "dev-master",
         "ext-memcache": "*",
-        "microsoft/windowsazure": ">=0.4.0"
+        "microsoft/windowsazure": ">=0.4.0",
+        "phpunit/phpunit": "^4.8.36"
     },
     "suggest": {
         "predis/predis": "For Redis backend support",

--- a/test/Demo/Workers/SampleWorkerTest.php
+++ b/test/Demo/Workers/SampleWorkerTest.php
@@ -1,5 +1,8 @@
 <?php
-class SampleWorkerTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class SampleWorkerTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/AmazonS3V1Test.php
+++ b/test/PHPQueue/Backend/AmazonS3V1Test.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
 
-class AmazonS3V1Test extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AmazonS3V1Test extends TestCase
 {
     /**
      * @var \PHPQueue\Backend\AmazonS3

--- a/test/PHPQueue/Backend/AmazonS3V2Test.php
+++ b/test/PHPQueue/Backend/AmazonS3V2Test.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
 
-class AmazonS3V2Test extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AmazonS3V2Test extends TestCase
 {
     /**
      * @var \Aws\S3\S3Client

--- a/test/PHPQueue/Backend/AmazonSQSV1Test.php
+++ b/test/PHPQueue/Backend/AmazonSQSV1Test.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
 
-class AmazonSQSV1Test extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AmazonSQSV1Test extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/AmazonSQSV2Test.php
+++ b/test/PHPQueue/Backend/AmazonSQSV2Test.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
 
-class AmazonSQSV2Test extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AmazonSQSV2Test extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/BeanstalkdTest.php
+++ b/test/PHPQueue/Backend/BeanstalkdTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class BeanstalkdTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class BeanstalkdTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/CSVTest.php
+++ b/test/PHPQueue/Backend/CSVTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class CSVTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class CSVTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/IronMQTest.php
+++ b/test/PHPQueue/Backend/IronMQTest.php
@@ -1,9 +1,12 @@
 <?php
 namespace PHPQueue\Backend;
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * @testdox To enable test: Save iron.json to ~/.iron.json in your home folder.
  */
-class IronMQTest extends \PHPUnit_Framework_TestCase
+class IronMQTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/LocalFSTest.php
+++ b/test/PHPQueue/Backend/LocalFSTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHPQueue\Backend;
 
+use PHPUnit\Framework\TestCase;
+
 class LocalFSMock extends LocalFS
 {
     public function getContainerPath($directory_name)
@@ -19,7 +21,7 @@ class LocalFSMock extends LocalFS
     }
 }
 
-class LocalFSTest extends \PHPUnit_Framework_TestCase
+class LocalFSTest extends TestCase
 {
     /**
      * @var \PHPQueue\Backend\LocalFSMock

--- a/test/PHPQueue/Backend/MemcacheTest.php
+++ b/test/PHPQueue/Backend/MemcacheTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class MemcacheTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class MemcacheTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/MongoDBTest.php
+++ b/test/PHPQueue/Backend/MongoDBTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class MongoDBTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class MongoDBTest extends TestCase
 {
     private $object;
     private $ids = array();

--- a/test/PHPQueue/Backend/PDOBaseTest.php
+++ b/test/PHPQueue/Backend/PDOBaseTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
 
-abstract class PDOBaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class PDOBaseTest extends TestCase
 {
     /**
      * @var PDO

--- a/test/PHPQueue/Backend/PredisTest.php
+++ b/test/PHPQueue/Backend/PredisTest.php
@@ -2,8 +2,9 @@
 namespace PHPQueue\Backend;
 
 use PHPQueue\Exception\JsonException;
+use PHPUnit\Framework\TestCase;
 
-class PredisTest extends \PHPUnit_Framework_TestCase
+class PredisTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/Backend/StompTest.php
+++ b/test/PHPQueue/Backend/StompTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace PHPQueue\Backend;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PHPQueue\Exception\JobNotFoundException;
 
-class StompTest extends PHPUnit_Framework_TestCase
+class StompTest extends TestCase
 {
     protected $object;
     protected $unique;

--- a/test/PHPQueue/Backend/WindowsAzureBlobTest.php
+++ b/test/PHPQueue/Backend/WindowsAzureBlobTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class WindowsAzureBlobTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class WindowsAzureBlobTest extends TestCase
 {
     /**
      * @var \PHPQueue\Backend\WindowsAzureBlob

--- a/test/PHPQueue/Backend/WindowsAzureServiceBusTest.php
+++ b/test/PHPQueue/Backend/WindowsAzureServiceBusTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace PHPQueue\Backend;
-class WindowsAzureServiceBusTest extends \PHPUnit_Framework_TestCase
+
+use PHPUnit\Framework\TestCase;
+
+class WindowsAzureServiceBusTest extends TestCase
 {
     private $object;
 

--- a/test/PHPQueue/BaseTest.php
+++ b/test/PHPQueue/BaseTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace PHPQueue;
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class BaseTest extends TestCase
 {
     public function __construct($name = NULL, array $data = array(), $dataName = '')
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to require PHPUnit version [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.