### PR TITLE
Allow use of Monolog 2.x (as well as 1.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "monolog/monolog": "~1.3",
+        "monolog/monolog": "~1.3||~2",
         "clio/clio": "0.1.*"
     },
     "require-dev": {

--- a/demo/queues/BeanstalkSampleQueue.php
+++ b/demo/queues/BeanstalkSampleQueue.php
@@ -38,7 +38,7 @@ class BeanstalkSampleQueue extends PHPQueue\JobQueue
 
     public function updateJob($jobId = null, $resultData = null)
     {
-        $this->resultLog->addInfo('Result: ID='.$jobId, $resultData);
+        $this->resultLog->info('Result: ID='.$jobId, $resultData);
     }
 
     public function clearJob($jobId = null)


### PR DESCRIPTION
No changes needed to the Logger class itself, as the StreamHandler
constructor is compatible in 2.x. Usages of non-PSR-standard e.g.
Logger->addInfo() methods are replaced with PSR-standard e.g.
Logger->info() calls, as both exist in 1.x and the former are
removed in Monolog 2.

See https://github.com/Seldaek/monolog/blob/main/UPGRADE.md