### PR TITLE
Allow any version of MonoLog, remove unsupported repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,9 @@
             "email": "mcheng.work@gmail.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "pear",
-            "url": "http://pear.php.net"
-        }
-    ],
     "require": {
         "php": ">=5.3.0",
-        "monolog/monolog": "~1.3||~2",
+        "monolog/monolog": "*",
         "clio/clio": "0.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
Pear repo has been removed in Composer 2.0, monolog usage is pretty tame and should work across versions.