### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://github.com/CoderKungfu/php-queue",
     "type": "library",
     "license": "MIT",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "authors": [
         {
             "name": "Michael Cheng",
@@ -21,10 +21,9 @@
         "mrpoundsign/pheanstalk-5.3": "dev-master",
         "aws/aws-sdk-php": ">=2.8",
         "amazonwebservices/aws-sdk-for-php": "dev-master",
-        "predis/predis": "1.*",
+        "predis/predis": "1.*|2.*|3.*",
         "iron-io/iron_mq": "dev-master",
-        "ext-memcache": "*",
-        "microsoft/windowsazure": ">=0.4.0"
+        "ext-memcache": "*"
     },
     "suggest": {
         "predis/predis": "For Redis backend support",


### PR DESCRIPTION
Update compatible Predis versions. In local testing it seems to work up to 3.x without code changes.

Remove Azure from requires-dev. It's already in the 'suggest' section and the pinned version was tied to jwt versions affected by CVEs.